### PR TITLE
Improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Before starting this course, check the following requirements.
 2. Git version control system needs to be installed on your computer (link to the git site: https://git-scm.com/).
 3. Make sure that the path to the root folder of the course does not contain spaces, special characters, or non-Latin characters.
 4. Make sure that you use the [IntelliJ IDEA](https://www.jetbrains.com/idea/download/?_ga=2.189310830.494255415.1682514714-1823138827.1669894241&_gac=1.83806948.1682684894.Cj0KCQjw3a2iBhCFARIsAD4jQB3QkDU43KtbIx2HzEz02KvcN7Ma3QGzkIbyX4KS3H4x8b2bl9p4EfYaAvWsEALw_wcB&_gl=1*1h13lr8*_ga*MTgyMzEzODgyNy4xNjY5ODk0MjQx*_ga_9J976DJZ68*MTY4MjY5NDIyMy4xMjUuMS4xNjgyNjk0MjM4LjQ1LjAuMA..#section=windows) with version at least `2023.1.1`.
-5. Make sure that you use the [EduTools](https://plugins.jetbrains.com/plugin/10081-edutools) plugin with version at least `2023.1`.
+5. Make sure that you use the [JetBrains Academy](https://plugins.jetbrains.com/plugin/10081-jetbrains-academy) plugin with version at least `2023.1`.
 
 The course is integrated into the [IntelliJ IDEA IDE](https://www.jetbrains.com/idea/), which has a free Community license.
 You can use this license to complete the course.
@@ -51,7 +51,7 @@ or create a course archive from the source code.
 
 ### Getting started: create a course preview from the source code
 
-You can create a [course preview](https://plugins.jetbrains.com/plugin/10081-edutools/docs/educator-start-guide.html#preview_course) from the source code:
+You can create a [course preview](https://plugins.jetbrains.com/plugin/10081-jetbrains-academy/docs/educator-start-guide.html#preview_course) from the source code:
 1. Clone the repository:
     ```text
     git clone https://github.com/jetbrains-academy/refactoring-course.git
@@ -62,13 +62,13 @@ You can create a [course preview](https://plugins.jetbrains.com/plugin/10081-edu
     ./gradlew build
     ```
 
-3. Install the [EduTools](https://plugins.jetbrains.com/plugin/10081-edutools/docs/educational-products.html) plugin from JetBrains Marketplace.
+3. Install the [JetBrains Academy](https://plugins.jetbrains.com/plugin/10081-jetbrains-academy/docs/install-jetbrains-academy-plugin.html) plugin from JetBrains Marketplace.
 
-4. Create a new [course preview](https://plugins.jetbrains.com/plugin/10081-edutools/docs/educator-start-guide.html#preview_course).
+4. Create a new [course preview](https://plugins.jetbrains.com/plugin/10081-jetbrains-academy/docs/educator-start-guide.html#preview_course).
 
 ### Getting started: create a course archive
 
-You can create a [course archive](https://plugins.jetbrains.com/plugin/10081-edutools/docs/educator-start-guide.html#fe7010f2) from the source code:
+You can create a [course archive](https://plugins.jetbrains.com/plugin/10081-jetbrains-academy/docs/educator-start-guide.html#fe7010f2) from the source code:
 1. Clone the repository:
     ```text
     git clone https://github.com/jetbrains-academy/refactoring-course.git
@@ -79,9 +79,9 @@ You can create a [course archive](https://plugins.jetbrains.com/plugin/10081-edu
     ./gradlew build
     ```
 
-3. Install the [EduTools](https://plugins.jetbrains.com/plugin/10081-edutools/docs/educational-products.html) plugin from JetBrains Marketplace.
+3. Install the [JetBrains Academy](https://plugins.jetbrains.com/plugin/10081-jetbrains-academy/docs/install-jetbrains-academy-plugin.html) plugin from JetBrains Marketplace.
 
-4. Create a new [course archive](https://plugins.jetbrains.com/plugin/10081-edutools/docs/educator-start-guide.html#fe7010f2).
+4. Create a new [course archive](https://plugins.jetbrains.com/plugin/10081-jetbrains-academy/docs/educator-start-guide.html#fe7010f2).
 
 ## Run tests
 


### PR DESCRIPTION
- Use `JetBrains Academy` name instead of old `EduTools` one
- Adjust links on how to install the plugin
- Replace old plugin links with new ones to avoid unnecessary redirect