### PR TITLE
Improve GitHub action workflows

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -2,6 +2,12 @@ name: Gradle Build
 
 on: [push, pull_request]
 
+# Allow cancelling all previous runs for the same branch
+# See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -7,15 +7,15 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3.0.0
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.0.0
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: liberica
       - name: Gradle Wrapper Validation
         uses: gradle/wrapper-validation-action@v1.0.4
-      - uses: gradle/gradle-build-action@v2.1.5
+      - uses: gradle/gradle-build-action@v2
         with:
           arguments: build --stacktrace -x test      
     

--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3.0.0
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.0.0
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: liberica
       - name: Gradle Wrapper Validation
         uses: gradle/wrapper-validation-action@v1.0.4
-      - uses: gradle/gradle-build-action@v2.1.5
+      - uses: gradle/gradle-build-action@v2
         with:
           arguments: test

--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -2,6 +2,12 @@ name: Gradle Test
 
 on: [push, pull_request]
 
+# Allow cancelling all previous runs for the same branch
+# See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
- Update versions of some github actions to fix warning of deprecated API usages
- Cancel outdated runs of the same workflow. It's useful not to finish workflow and free runners after pushing new changes into the same branch. In most cases, you don't need previous results

| Warnings before | Warnings after |
| - | - |
| <img width="572" alt="Screenshot 2023-11-17 at 16 45 44" src="https://github.com/jetbrains-academy/refactoring-course/assets/2539310/b6d2bc22-a402-4744-ab44-2c3ccd35c5a0"> | <img width="715" alt="Screenshot 2023-11-17 at 16 53 57" src="https://github.com/jetbrains-academy/refactoring-course/assets/2539310/8b1cf80f-ae7c-44c0-adc4-28fc57e4a117"> |
