### PR TITLE
Add course links for course plan

### DIFF
--- a/Introduction/Introduction/Introduction/task.md
+++ b/Introduction/Introduction/Introduction/task.md
@@ -20,34 +20,34 @@ Embark on a coding journey with refactoring and design patterns – your path to
 
 <div class="hint" title="Course Plan"> 
 
-- **Section 1: Refactoring and its purpose**
-    - Lesson 1: What is code refactoring?
-    - Lesson 2: Common code issues and their impact on code quality
-    - Lesson 3: Refactoring techniques
-    - Lesson 4: Getting familiar with IDE refactoring features
-- **Section 2: Code style and Formatting**
-    - Lesson 1: What is code style and formatting?
+- **[Section 1: Refactoring and its purpose](course://RefactoringAndItsPurpose)**
+    - [Lesson 1: What is code refactoring?](course://RefactoringAndItsPurpose/WhatIsCodeRefactoring)
+    - [Lesson 2: Common code issues and their impact on code quality](course://RefactoringAndItsPurpose/CommonCodeIssuesAndTheirImpactOnCodeQuality)
+    - [Lesson 3: Refactoring techniques](course://RefactoringAndItsPurpose/RefactoringTechniques)
+    - [Lesson 4: Getting familiar with IDE refactoring features](course://RefactoringAndItsPurpose/GettingFamiliarWithIDERefactoringFeatures)
+- **[Section 2: Code style and Formatting](course://CodeStyleAndFormatting)**
+    - [Lesson 1: What is code style and formatting?](course://CodeStyleAndFormatting/WhatIsFormatting)
     - Lesson 2: Reformat the code using IDE
-    - Lesson 3: Code schemas and EditorConfig
-- **Section 3: Renaming code**
-    - Lesson 1: Naming rules
-    - Lesson 2: Rename refactoring in IDE
-- **Section 4: Moving code**
-    - Lesson 1: Cohesion and coupling
-    - Lesson 2: What is Move refactoring?
-    - Lesson 3: What are Pull Up and Push Down refactorings?
-- **Section 5: Extracting code**
-    - Lesson 1: What is Extract Function refactoring?
-    - Lesson 2: What is Extract Variable refactoring?
-- **Section 6: Inlining code**
-    - Lesson 1: What is Inline Variable refactoring?
-    - Lesson 2: Inline Method refactoring
-    - Lesson 3: Middle Man code smell
-- **Section 7: Refactoring to Design patterns**
-    - Lesson 1: Design patterns and their relationships with refactoring
-    - Lesson 2: Facade Pattern	
-    - Lesson 3: Strategy Pattern	
-    - Lesson 4: Factory Method Pattern
-- **Section 8: Conclusion**
+    - [Lesson 3: Code schemas and EditorConfig](course://CodeStyleAndFormatting/CodeSchemasAndEditorConfig)
+- **[Section 3: Renaming code](course://RenamingCode)**
+    - [Lesson 1: Naming rules](course://RenamingCode/NamingRules)
+    - [Lesson 2: Rename refactoring in IDE](course://RenamingCode/RenameRefactoringInIDE)
+- **[Section 4: Moving code](course://MovingCode)**
+    - [Lesson 1: Cohesion and coupling](course://MovingCode/CohesionAndCoupling)
+    - [Lesson 2: What is Move refactoring?](course://MovingCode/WhatIsMoveMethodRefactoring)
+    - [Lesson 3: What are Pull Up and Push Down refactorings?](course://MovingCode/WhatArePullUpAndPushDownRefactorings)
+- **[Section 5: Extracting code](course://ExtractingCode)**
+    - [Lesson 1: What is Extract Method refactoring?](course://ExtractingCode/WhatIsExtractMethodRefactoring)
+    - [Lesson 2: What is Extract Variable refactoring?](course://ExtractingCode/WhatIsExtractVariableRefactoring)
+- **[Section 6: Inlining code](course://InliningCode)**
+    - [Lesson 1: What is Inline Variable refactoring?](course://InliningCode/WhatIsInlineVariableRefactoring)
+    - [Lesson 2: Inline Method refactoring](course://InliningCode/InlineMethodRefactoring)
+    - [Lesson 3: Middle Man code smell](course://InliningCode/MiddleManCodeSmell)
+- **[Section 7: Refactoring to Design patterns](course://RefactoringToDesignPatterns)**
+    - [Lesson 1: Design patterns and their relationships with refactoring](course://RefactoringToDesignPatterns/DesignPatternsAndTheirRelationshipsWithRefactoring)
+    - [Lesson 2: Facade Pattern](course://RefactoringToDesignPatterns/FacadePatternTheory)
+    - [Lesson 3: Strategy Pattern](course://RefactoringToDesignPatterns/StrategyPatternTheory)
+    - [Lesson 4: Factory Method Pattern](course://RefactoringToDesignPatterns/FactoryMethodPatternTheory)
+- **[Section 8: Conclusion](course://Conclusion)**
     - Next steps for further learning
 </div>


### PR DESCRIPTION
These changes add course links to course structure in the description of `Introduction` task

**Before**:

Just a plain text course structure

<img width="1512" alt="Screenshot 2023-11-17 at 17 22 36" src="https://github.com/jetbrains-academy/refactoring-course/assets/2539310/9c01c9fc-dfd5-427e-a364-772d2d06be3a">


**After**:
Interactive links to course items

https://github.com/jetbrains-academy/refactoring-course/assets/2539310/ef5075d5-d845-4ffd-8cfa-843d4c8e3582